### PR TITLE
fix: add security hardening flags to build configuration

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,12 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 export DEB_CXXFLAGS_MAINT_APPEND = -Ofast
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for comprehensive
security
2. Included -Wall flag for both C and C++ compilers to enable all
warnings
3. Added secure linker flags (-Wl) for RELRO, immediate binding,
noexecstack protection
4. These changes improve binary security by enabling modern protection
mechanisms

fix: 在构建配置中添加安全加固标志

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以实现全面的安全
保护
2. 为 C 和 C++ 编译器包含 -Wall 标志以启用所有警告
3. 添加安全链接器标志 (-Wl) 用于 RELRO、立即绑定和 noexecstack 保护
4. 这些更改通过启用现代保护机制来提高二进制文件的安全性
